### PR TITLE
Adding the cancel action to the bottom of the list.

### DIFF
--- a/GitYourFeedback/Classes/FeedbackViewController.swift
+++ b/GitYourFeedback/Classes/FeedbackViewController.swift
@@ -172,6 +172,12 @@ class FeedbackInterfaceViewController: UIViewController {
             self.image = nil
         }
         actionSheet.addAction(removeAction)
+
+        let cancelAction = UIAlertAction(title: "Cancel", style: .default) { (action) in
+            // No action needed...
+        }
+        actionSheet.addAction(cancelAction)
+
         
         present(actionSheet, animated: true, completion: nil)
     }


### PR DESCRIPTION
Fixes #24 

Thanks for creating this issue!

I'm only just starting out with Swift, but I believe I've done this correctly. I'm happy to revisit if there is more you'd like.

I put the cancel option at the bottom so as to keep it logically separated from the 'actual' actions.

<img width="311" alt="screen shot 2016-10-22 at 12 09 42 pm" src="https://cloud.githubusercontent.com/assets/933586/19620691/67a98b88-9850-11e6-8b3f-392691937801.png">
